### PR TITLE
Fix NRQL alert condition duration

### DIFF
--- a/newrelic/resource_newrelic_nrql_alert_condition.go
+++ b/newrelic/resource_newrelic_nrql_alert_condition.go
@@ -75,7 +75,7 @@ func resourceNewRelicNrqlAlertCondition() *schema.Resource {
 						"duration": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: intInSlice([]int{1, 2, 3, 4, 5, 10, 15, 30, 60, 120}),
+							ValidateFunc: validation.IntBetween(2, 120),
 						},
 						"operator": {
 							Type:         schema.TypeString,


### PR DESCRIPTION
Acceptable values for a NRQL alert duration range from 2-120 (inclusive).